### PR TITLE
Filter by active content elements first before deduplicating references

### DIFF
--- a/Classes/Domain/Repository/FileReferenceRepository.php
+++ b/Classes/Domain/Repository/FileReferenceRepository.php
@@ -50,8 +50,8 @@ class FileReferenceRepository extends Repository
         $event = new AfterImageReferencesLoadedEvent($result->toArray());
         $this->eventDispatcher->dispatch($event);
 
-        $result = array_filter(
-            ArrayUtility::uniqueObjectsByProperty($event->getFileReferences(), 'uidLocal'),
+        $result = ArrayUtility::uniqueObjectsByProperty(array_filter(
+            $event->getFileReferences(),
             function (FileReference $reference) {
                 $qb = $this->connectionPool->getQueryBuilderForTable($reference->getTablenames());
                 $query = $qb->from($reference->getTablenames())
@@ -66,7 +66,7 @@ class FileReferenceRepository extends Repository
                 $rowCount = $query->executeQuery()->rowCount();
                 return $rowCount > 0;
             }
-        );
+        ), 'uidLocal');
 
         $event = new AfterImageReferencesDeduplicatedEvent($result);
         $this->eventDispatcher->dispatch($event);


### PR DESCRIPTION
This fixes a bug where the image credits for an image would not show up if there were two content elements on a page referencing the same image and the first content element being disabled.